### PR TITLE
Move navigation to sidebar

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,14 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_theme = 'alabaster'
 html_static_path = ['_static']
 
+# Show the full navigation hierarchy in the sidebar
+html_theme_options = {
+    'sidebar_collapse': False,
+}
+html_sidebars = {
+    '**': ['about.html', 'globaltoc.html', 'searchbox.html'],
+}
+
 # -- Extension configuration -------------------------------------------------
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Create synthetic datasets with LLM generators and samplers.
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   :hidden:
 
    quickstart
    examples


### PR DESCRIPTION
## Summary
- hide the TOC on `index.rst` so it only shows in the sidebar
- expand the full hierarchy in the sidebar navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `sphinx-build -b html docs/source docs/_build/html` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684731fc04308320a2720ad8ad758ec4