### PR TITLE
Add HuggingFace transformers generator

### DIFF
--- a/docs/source/other_examples.rst
+++ b/docs/source/other_examples.rst
@@ -70,4 +70,22 @@ Dataset Triton
     final_df = final_ds.generate(1000)
     final_ds.save("triton_kernel_dataset.parquet")
 
+Transformers Local Generation
+----------------------------------------------
+
+.. code-block:: python
+
+   from chatan import generator, dataset, sample
+
+   # Use a local HuggingFace model
+   gen = generator("transformers", model="gpt2")
+
+   ds = dataset({
+       "topic": sample.choice(["space", "history", "science"]),
+       "prompt": gen("Ask a short question about {topic}"),
+       "response": gen("{prompt}")
+   })
+
+   df = ds.generate(5)
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "openai>=1.0.0",
     "anthropic>=0.7.0",
+    "transformers>=4.0.0",
     "datasets>=2.0.0",
     "pandas>=1.3.0",
     "numpy>=1.20.0",


### PR DESCRIPTION
## Summary
- support transformers pipeline based generator
- document local transformers use
- enable provider in GeneratorClient and factory
- test huggingface generator integration
- declare transformers dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/chatan)*

------
https://chatgpt.com/codex/tasks/task_e_684760fefcdc8320b9234b3bc3bca729