### PR TITLE
Add default progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ds = chatan.dataset({
     "response": gen("answer this question: {prompt}")
 })
 
-# Generate the data
+# Generate the data with a progress bar
 df = ds.generate(n=10)
 ```
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ Quick Start
        "response": gen("answer this question: {prompt}")
    })
 
-   # Generate the data
+   # Generate the data with a progress bar
    df = ds.generate(n=10)
 
 Indices and tables

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -37,7 +37,7 @@ Basic Usage
 
    .. code-block:: python
 
-      # Generate 100 samples
+      # Generate 100 samples with a progress bar
       df = ds.generate(100)
       
       # Save to file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pandas>=1.3.0",
     "numpy>=1.20.0",
     "pydantic>=2.0.0",
+    "tqdm>=4.0.0",
 ]
 
 [dependency-groups]

--- a/src/chatan/__init__.py
+++ b/src/chatan/__init__.py
@@ -1,6 +1,6 @@
 """Minos: Create synthetic datasets with LLM generators and samplers."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from .dataset import dataset
 from .generator import generator

--- a/src/chatan/dataset.py
+++ b/src/chatan/dataset.py
@@ -3,6 +3,7 @@
 from typing import Dict, Any, Union, Optional, List, Callable
 import pandas as pd
 from datasets import Dataset as HFDataset
+from tqdm import tqdm
 from .generator import GeneratorFunction
 from .sampler import SampleFunction
 
@@ -27,17 +28,34 @@ class Dataset:
         self.n = n
         self._data = None
     
-    def generate(self, n: Optional[int] = None) -> pd.DataFrame:
-        """Generate the dataset."""
+    def generate(
+        self, n: Optional[int] = None, progress: bool = True
+    ) -> pd.DataFrame:
+        """Generate the dataset.
+
+        Parameters
+        ----------
+        n:
+            Number of samples to generate. Defaults to the value provided at
+            initialization.
+        progress:
+            Whether to display a progress bar. Defaults to ``True``. Pass
+            ``False`` to disable the progress output.
+        """
         num_samples = n or self.n
-        
+        show_progress = progress
+
         # Build dependency graph
         dependencies = self._build_dependency_graph()
         execution_order = self._topological_sort(dependencies)
-        
+
         # Generate data
         data = []
-        for i in range(num_samples):
+        iterator = range(num_samples)
+        if show_progress:
+            iterator = tqdm(iterator, desc="Generating", leave=False)
+
+        for _ in iterator:
             row = {}
             for column in execution_order:
                 value = self._generate_value(column, row)


### PR DESCRIPTION
## Summary
- show a progress bar by default when generating datasets
- remove `progress=True` from documentation examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c2532608083208ca87707c9ba2dac