### PR TITLE
Add docs for evaluation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ ds = dataset({
 
 ```
 
+## Evaluation
+
+Evaluate rows inline or compute aggregate metrics:
+
+```python
+from chatan import dataset, eval, sample
+
+ds = dataset({
+    "col1": sample.choice(["a", "a", "b"]),
+    "col2": "b",
+    "score": eval.exact_match("col1", "col2")
+})
+
+df = ds.generate()
+aggregate = ds.evaluate({
+    "exact_match": ds.eval.exact_match("col1", "col2")
+})
+```
+
 ## Citation
 
 If you use this code in your research, please cite:

--- a/docs/source/evaluation.rst
+++ b/docs/source/evaluation.rst
@@ -1,0 +1,59 @@
+Evaluation
+==========
+
+Chatan includes helpers for evaluating generated data. Metrics can be computed
+while rows are created or aggregated afterwards.
+
+Inline evaluation
+-----------------
+Add evaluation functions directly in the dataset schema. The resulting column
+contains the score for each row.
+
+.. code-block:: python
+
+   from chatan import dataset, eval, sample
+
+   ds = dataset({
+       "col1": sample.choice(["a", "a", "b"]),
+       "col2": "b",
+       "exact_match": eval.exact_match("col1", "col2")
+   }, n=100)
+
+   df = ds.generate()
+   print(df.head())
+
+Aggregate evaluation
+--------------------
+Compute metrics across the dataset using ``Dataset.evaluate`` and the
+``Dataset.eval`` helper.
+
+.. code-block:: python
+
+   aggregate = ds.evaluate({
+       "exact_match": ds.eval.exact_match("col1", "col2"),
+   })
+   print(aggregate)
+
+Comparing variations
+--------------------
+Evaluate multiple columns—useful for comparing different prompts or models.
+
+.. code-block:: python
+
+   ds = dataset({
+       "sample_1": sample.choice(["a", "a", "b"]),
+       "sample_2": sample.choice(["a", "b"]),
+       "ground_truth": "b",
+   }, n=100)
+
+   df = ds.generate()
+   results = ds.evaluate({
+       "sample_1_match": ds.eval.exact_match("sample_1", "ground_truth"),
+       "sample_2_match": ds.eval.exact_match("sample_2", "ground_truth"),
+   })
+
+Supported metrics
+-----------------
+The ``evaluate`` module provides metrics such as exact match, semantic similarity,
+BLEU score, edit distance and an LLM-as-a-judge metric. Access them through
+``ds.eval`` for aggregate evaluation or ``eval`` for inline use.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Create synthetic datasets with LLM generators and samplers.
    quickstart
    examples
    other_examples
+   evaluation
    api
 
 Installation


### PR DESCRIPTION
## Summary
- document the new evaluation API
- include evaluation examples in README
- add dedicated evaluation docs page and link it from the index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f4b2396dc8320829fe9b0adc31f10