### PR TITLE
Add provider and evaluator summaries

### DIFF
--- a/docs/source/datasets_and_generators.rst
+++ b/docs/source/datasets_and_generators.rst
@@ -5,6 +5,15 @@ Chatan builds datasets from two simple concepts. **Generators** call large
 language models while **samplers** create structured values. Together they form
 the schema for a ``Dataset``.
 
+Supported generator providers
+-----------------------------
+Chatan includes built-in clients for a few common model sources:
+
+* ``openai`` - access GPT models via the OpenAI API
+* ``anthropic`` - use Claude models from Anthropic
+* ``transformers``/``huggingface`` - run local HuggingFace models with ``transformers``
+
+
 Basic QA Dataset
 ----------------
 A minimal dataset uses a single generator to create questions and answers.

--- a/docs/source/evaluators.rst
+++ b/docs/source/evaluators.rst
@@ -4,6 +4,10 @@ Evaluators
 Evaluation helpers let you score generated data. Metrics can run inline as
 columns are produced or over the entire dataset after generation.
 
+Available evaluation functions
+------------------------------
+Current helpers include exact match, semantic similarity, BLEU score, normalized edit distance and an LLM-as-a-judge metric.
+
 Inline evaluation
 -----------------
 Add evaluation functions directly to the dataset schema. Each row will include a


### PR DESCRIPTION
## Summary
- document which model providers `generator` supports
- summarize available evaluation helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f55c58a008320b3a839b029cf78a7