### PR TITLE
Add Azure OpenAI generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ import chatan
 
 # Create a generator
 gen = chatan.generator("openai", "YOUR_API_KEY")
+# or Azure OpenAI
+# gen = chatan.generator(
+#     "azure-openai",
+#     "YOUR_AZURE_API_KEY",
+#     azure_endpoint="https://YOUR-RESOURCE.openai.azure.com/",
+#     api_version="2024-02-01"
+# )
 
 # Define a dataset schema
 ds = chatan.dataset({

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -18,8 +18,15 @@ Basic Usage
    .. code-block:: python
 
       import chatan
-      
+
       gen = chatan.generator("openai", "YOUR_OPENAI_API_KEY")
+      # or for Azure OpenAI
+      # gen = chatan.generator(
+      #     "azure-openai",
+      #     "YOUR_AZURE_API_KEY",
+      #     azure_endpoint="https://YOUR-RESOURCE.openai.azure.com/",
+      #     api_version="2024-02-01"
+      # )
       # or for Anthropic
       # gen = chatan.generator("anthropic", "YOUR_ANTHROPIC_API_KEY")
 
@@ -47,7 +54,7 @@ Core Concepts
 -------------
 
 **Generators**
-   Use LLMs to create text content. Support OpenAI and Anthropic APIs.
+   Use LLMs to create text content. Support OpenAI, Azure OpenAI, and Anthropic APIs.
 
 **Samplers** 
    Create structured data like UUIDs, choices, ranges, dates.

--- a/src/chatan/generator.py
+++ b/src/chatan/generator.py
@@ -1,20 +1,21 @@
 """LLM generators for synthetic data creation with async support."""
 
-from typing import Dict, Any, Optional, Union, List
-import openai
-import anthropic
-from abc import ABC, abstractmethod
 import asyncio
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+import anthropic
+import openai
 
 
 class BaseGenerator(ABC):
     """Base class for LLM generators."""
-    
+
     @abstractmethod
     def generate(self, prompt: str, **kwargs) -> str:
         """Generate content from a prompt."""
         pass
-    
+
     @abstractmethod
     async def generate_async(self, prompt: str, **kwargs) -> str:
         """Generate content from a prompt asynchronously."""
@@ -23,66 +24,109 @@ class BaseGenerator(ABC):
 
 class OpenAIGenerator(BaseGenerator):
     """OpenAI GPT generator with async support."""
-    
+
     def __init__(self, api_key: str, model: str = "gpt-3.5-turbo", **kwargs):
         self.client = openai.OpenAI(api_key=api_key)
         self.async_client = openai.AsyncOpenAI(api_key=api_key)
         self.model = model
         self.default_kwargs = kwargs
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         """Generate content using OpenAI API."""
         merged_kwargs = {**self.default_kwargs, **kwargs}
-        
+
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
-            **merged_kwargs
+            **merged_kwargs,
         )
         return response.choices[0].message.content.strip()
-    
+
     async def generate_async(self, prompt: str, **kwargs) -> str:
         """Generate content using OpenAI API asynchronously."""
         merged_kwargs = {**self.default_kwargs, **kwargs}
-        
+
         response = await self.async_client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
-            **merged_kwargs
+            **merged_kwargs,
+        )
+        return response.choices[0].message.content.strip()
+
+
+class AzureOpenAIGenerator(BaseGenerator):
+    """Azure OpenAI GPT generator with async support."""
+
+    def __init__(
+        self,
+        api_key: str,
+        azure_endpoint: str,
+        api_version: str = "2024-02-01",
+        model: str = "gpt-35-turbo",
+        **kwargs,
+    ):
+        self.client = openai.AzureOpenAI(
+            api_key=api_key, api_version=api_version, azure_endpoint=azure_endpoint
+        )
+        self.async_client = openai.AsyncAzureOpenAI(
+            api_key=api_key, api_version=api_version, azure_endpoint=azure_endpoint
+        )
+        self.model = model
+        self.default_kwargs = kwargs
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        """Generate content using Azure OpenAI API."""
+        merged_kwargs = {**self.default_kwargs, **kwargs}
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            **merged_kwargs,
+        )
+        return response.choices[0].message.content.strip()
+
+    async def generate_async(self, prompt: str, **kwargs) -> str:
+        """Generate content using Azure OpenAI API asynchronously."""
+        merged_kwargs = {**self.default_kwargs, **kwargs}
+
+        response = await self.async_client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            **merged_kwargs,
         )
         return response.choices[0].message.content.strip()
 
 
 class AnthropicGenerator(BaseGenerator):
     """Anthropic Claude generator with async support."""
-    
+
     def __init__(self, api_key: str, model: str = "claude-3-sonnet-20240229", **kwargs):
         self.client = anthropic.Anthropic(api_key=api_key)
         self.async_client = anthropic.AsyncAnthropic(api_key=api_key)
         self.model = model
         self.default_kwargs = kwargs
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         """Generate content using Anthropic API."""
         merged_kwargs = {**self.default_kwargs, **kwargs}
-        
+
         response = self.client.messages.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=merged_kwargs.pop("max_tokens", 1000),
-            **merged_kwargs
+            **merged_kwargs,
         )
         return response.content[0].text.strip()
-    
+
     async def generate_async(self, prompt: str, **kwargs) -> str:
         """Generate content using Anthropic API asynchronously."""
         merged_kwargs = {**self.default_kwargs, **kwargs}
-        
+
         response = await self.async_client.messages.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=merged_kwargs.pop("max_tokens", 1000),
-            **merged_kwargs
+            **merged_kwargs,
         )
         return response.content[0].text.strip()
 
@@ -109,7 +153,7 @@ class GeneratorFunction:
         prompt = self.prompt_template.format(**merged)
         result = self.generator.generate(prompt)
         return result.strip() if isinstance(result, str) else result
-    
+
     async def generate_async(self, context: Dict[str, Any]) -> str:
         """Generate content with context substitution (async)."""
         merged = dict(context)
@@ -128,15 +172,18 @@ class GeneratorFunction:
 
 class GeneratorClient:
     """Main interface for creating generators."""
-    
+
     def __init__(self, provider: str, api_key: str, **kwargs):
-        if provider.lower() == "openai":
+        provider_key = provider.lower()
+        if provider_key == "openai":
             self._generator = OpenAIGenerator(api_key, **kwargs)
-        elif provider.lower() == "anthropic":
+        elif provider_key == "anthropic":
             self._generator = AnthropicGenerator(api_key, **kwargs)
+        elif provider_key in {"azure-openai", "azure_openai", "azure"}:
+            self._generator = AzureOpenAIGenerator(api_key, **kwargs)
         else:
             raise ValueError(f"Unsupported provider: {provider}")
-    
+
     def __call__(self, prompt_template: str, **variables) -> GeneratorFunction:
         """Create a generator function.
 
@@ -153,7 +200,9 @@ class GeneratorClient:
 
 
 # Factory function
-def generator(provider: str = "openai", api_key: Optional[str] = None, **kwargs) -> GeneratorClient:
+def generator(
+    provider: str = "openai", api_key: Optional[str] = None, **kwargs
+) -> GeneratorClient:
     """Create a generator client."""
     if api_key is None:
         raise ValueError("API key is required")


### PR DESCRIPTION
## Summary
- add AzureOpenAIGenerator with sync/async methods
- allow `azure-openai` provider in GeneratorClient
- document Azure usage in README and quickstart
- cover Azure provider with unit and integration tests

## Testing
- `isort src/chatan/generator.py tests/test_generator.py`
- `black src/chatan/generator.py tests/test_generator.py`
- `mypy src/chatan/` *(fails: Library stubs not installed for "pandas" and other modules)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas datasets` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a3459dcf1483208bc7e35f8472b746