### PR TITLE
Support explicit callable column dependencies in dataset schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ ds = dataset({
     "file_path": call(lambda: get_random_filepath()),
     "file_content": call(
         lambda ctx: get_file_content(ctx["file_path"]),
-        with_=["file_path"],
+        requires=["file_path"],
     ),
 })
 ```
 
 You can also use tuple syntax: `"file_content": (callable_fn, ["file_path"])`.
-(`with` is a Python keyword, so use `with_` in normal calls.)
 
 ## Generator Options
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ ds = dataset({
 
 You can also use tuple syntax: `"file_content": (callable_fn, ["file_path"])`.
 
+If your callable argument names match column names, dependencies are inferred automatically:
+
+```python
+def get_file_chunk(file_path):
+    return load_chunk(file_path)
+
+ds = dataset({
+    "file_path": call(get_random_filepath),
+    "file_chunk": call(get_file_chunk),  # infers dependency on file_path
+})
+```
+
 ## Generator Options
 
 ### API-based Generators (included in base install)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ async def main():
 df = asyncio.run(main())
 ```
 
+### Explicit Dependencies For Callables
+
+For plain callables, declare dependencies explicitly when one column needs another:
+
+```python
+from chatan import dataset, depends_on
+
+ds = dataset({
+    "file_path": lambda ctx: get_random_filepath(),
+    "file_content": depends_on(
+        lambda ctx: get_file_content(ctx["file_path"]),
+        "file_path",
+    ),
+})
+```
+
+You can also use tuple syntax: `"file_content": (callable_fn, ["file_path"])`.
+
 ## Generator Options
 
 ### API-based Generators (included in base install)

--- a/README.md
+++ b/README.md
@@ -50,18 +50,19 @@ df = asyncio.run(main())
 For plain callables, declare dependencies explicitly when one column needs another:
 
 ```python
-from chatan import dataset, depends_on
+from chatan import call, dataset
 
 ds = dataset({
-    "file_path": lambda ctx: get_random_filepath(),
-    "file_content": depends_on(
+    "file_path": call(lambda: get_random_filepath()),
+    "file_content": call(
         lambda ctx: get_file_content(ctx["file_path"]),
-        "file_path",
+        with_=["file_path"],
     ),
 })
 ```
 
 You can also use tuple syntax: `"file_content": (callable_fn, ["file_path"])`.
+(`with` is a Python keyword, so use `with_` in normal calls.)
 
 ## Generator Options
 

--- a/src/chatan/__init__.py
+++ b/src/chatan/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.3.0"
 
-from .dataset import dataset, depends_on
+from .dataset import call, dataset, depends_on
 from .evaluate import eval, evaluate
 from .generator import generator
 from .sampler import sample
@@ -10,6 +10,7 @@ from .viewer import generate_with_viewer
 
 __all__ = [
     "dataset",
+    "call",
     "depends_on",
     "generator",
     "sample",

--- a/src/chatan/__init__.py
+++ b/src/chatan/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.3.0"
 
-from .dataset import dataset
+from .dataset import dataset, depends_on
 from .evaluate import eval, evaluate
 from .generator import generator
 from .sampler import sample
@@ -10,6 +10,7 @@ from .viewer import generate_with_viewer
 
 __all__ = [
     "dataset",
+    "depends_on",
     "generator",
     "sample",
     "generate_with_viewer",

--- a/src/chatan/dataset.py
+++ b/src/chatan/dataset.py
@@ -334,7 +334,11 @@ class DependentCallable:
 
 
 def call(
-    func: Callable[..., Any], *dependencies: str, with_: Optional[List[str]] = None, **kwargs
+    func: Callable[..., Any],
+    *dependencies: str,
+    requires: Optional[List[str]] = None,
+    with_: Optional[List[str]] = None,
+    **kwargs,
 ) -> DependentCallable:
     """Declare callable schema entries and optional explicit dependencies.
 
@@ -343,7 +347,7 @@ def call(
             "file_path": call(lambda: random_path()),
             "file_content": call(
                 lambda ctx: load(ctx["file_path"]),
-                with_=["file_path"],
+                requires=["file_path"],
             ),
         }
     """
@@ -353,6 +357,11 @@ def call(
         raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
 
     explicit = list(dependencies)
+    if requires:
+        if isinstance(requires, str):
+            explicit.append(requires)
+        else:
+            explicit.extend(requires)
     if with_:
         explicit.extend(with_)
     if with_deps:


### PR DESCRIPTION
## Summary
- add explicit dependency support for plain callable columns via `depends_on(...)`
- support tuple syntax for callables: `(callable_fn, ["dep_col"])`
- include these explicit deps in the dependency graph/topological ordering
- export `depends_on` from package root and document usage in README
- add tests covering dependency graph + generation for both callable patterns

## Testing
- uv run pytest -q tests/test_dataset_comprehensive.py tests/test_datset.py
